### PR TITLE
build_colr.sh: always git-sync-deps before build

### DIFF
--- a/build_colr.sh
+++ b/build_colr.sh
@@ -1,16 +1,6 @@
 #!/bin/bash -x
 
-function fetch_drott_colr() {
-	pushd third_party/externals/freetype
-	git remote add drott_ft_colr https://github.com/drott/freetype2-colr
-	git fetch drott_ft_colr
-	git checkout -b colr_v1_dag drott_ft_colr/colrV1APIGraph
-	popd
-}
-
-[ -e ./bin/gn ] || ./bin/fetch-gn
-[ -d third_party/externals ] || ./tools/git-sync-deps
-# [ "colr_v1_dag" == "$(cd third_party/externals/freetype && git rev-parse --abbrev-ref HEAD)" ] || fetch_drott_colr
+./tools/git-sync-deps
 [ -d out/Static ] || mkdir -p out/Static
 
 set -e


### PR DESCRIPTION
to make sure deps are always up to date when pulling new commits, switching branch, etc.
 
git-sync-deps also automatically calls fetch-gn so we don't need to call it ourselves.

Also remove unused drott's freetype2 fork.